### PR TITLE
Improve test setup and configuration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    explicit_activerecord (0.1.0)
+    explicit_activerecord (0.1.1)
       activerecord
       activesupport
       deprecation_helper

--- a/spec/explicit_activerecord/no_db_access_spec.rb
+++ b/spec/explicit_activerecord/no_db_access_spec.rb
@@ -1,32 +1,22 @@
 # typed: false
-class ApplicationRecord < ActiveRecord::Base
-  self.abstract_class = true
-end
-
-class Foo < ApplicationRecord
-end
 
 module ExplicitActiveRecord
   describe NoDBAccess do
     include NoDBAccess
 
-    after do
-      Foo.delete_all
-    end
-
     describe '#no_db_access' do
       it 'allows saving' do
-        Foo.create! name: 'george'
-        foo = Foo.first
-        foo.name = 'bob'
-        foo.save!
+        TestClass.create! name: 'george'
+        test_class = TestClass.first
+        test_class.name = 'bob'
+        test_class.save!
       end
 
       it 'prevents raw sql' do
-        Foo.create! name: 'george'
+        TestClass.create! name: 'george'
         expect do
           no_db_access do
-            Foo.connection.execute('select * from foos')
+            TestClass.connection.execute('select * from test_classes')
           end
         end.to raise_error NoDBAccess::DbAccessError
       end
@@ -34,39 +24,58 @@ module ExplicitActiveRecord
       it 'prevents finding even when no record are returned' do
         expect do
           no_db_access do
-            Foo.first
+            TestClass.first
           end
         end.to raise_error NoDBAccess::DbAccessError
       end
 
       it 'prevents plucking in a pure function' do
-        Foo.create! name: 'george'
+        TestClass.create! name: 'george'
         expect do
           no_db_access do
-            expect(Foo.pluck(:name)).to eq(['george'])
+            expect(TestClass.pluck(:name)).to eq(['george'])
+          end
+        end.to raise_error NoDBAccess::DbAccessError
+      end
+
+      it 'prevents dynamic finds in a pure function' do
+        TestClass.create! name: 'george'
+        expect do
+          no_db_access do
+            expect(TestClass.find_by_name('george')).to eq TestClass.first
+          end
+        end.to raise_error NoDBAccess::DbAccessError
+      end
+
+      it 'prevents joins in a pure function' do
+        test_class = TestClass.create!
+        5.times { OtherTestClass.create!(test_class_id: test_class.id) }
+        expect do
+          no_db_access do
+            expect(TestClass.joins(:other_test_classes).uniq).to eq([TestClass.first])
           end
         end.to raise_error NoDBAccess::DbAccessError
       end
 
       it 'prevents finding in a pure function' do
-        Foo.create! name: 'george'
+        TestClass.create! name: 'george'
         expect do
           no_db_access do
-            Foo.first
+            TestClass.first
           end
         end.to raise_error NoDBAccess::DbAccessError
       end
 
       it 'prevents saving in a pure function' do
-        foo = Foo.create! name: 'george'
+        test_class = TestClass.create! name: 'george'
         puts 'point 1'
         no_db_access do
-          foo.name = 'bob'
+          test_class.name = 'bob'
         end
         expect do
           puts 'point 2'
           no_db_access do
-            foo.save!
+            test_class.save!
           end
         end.to raise_error NoDBAccess::DbAccessError
       end
@@ -74,16 +83,16 @@ module ExplicitActiveRecord
       it 'prevents creating in a pure function' do
         expect do
           no_db_access do
-            Foo.create! name: 'stuff'
+            TestClass.create! name: 'stuff'
           end
         end.to raise_error NoDBAccess::DbAccessError
       end
 
       it 'prevents destroying in a pure function' do
-        foo = Foo.create! name: 'stuff'
+        test_class = TestClass.create! name: 'stuff'
         expect do
           no_db_access do
-            foo.destroy
+            test_class.destroy
           end
         end.to raise_error NoDBAccess::DbAccessError
       end

--- a/spec/explicit_activerecord/no_db_access_spec.rb
+++ b/spec/explicit_activerecord/no_db_access_spec.rb
@@ -6,17 +6,17 @@ module ExplicitActiveRecord
 
     describe '#no_db_access' do
       it 'allows saving' do
-        TestClass.create! name: 'george'
-        test_class = TestClass.first
-        test_class.name = 'bob'
-        test_class.save!
+        TestModel.create! name: 'george'
+        test_model = TestModel.first
+        test_model.name = 'bob'
+        test_model.save!
       end
 
       it 'prevents raw sql' do
-        TestClass.create! name: 'george'
+        TestModel.create! name: 'george'
         expect do
           no_db_access do
-            TestClass.connection.execute('select * from test_classes')
+            TestModel.connection.execute('select * from test_models')
           end
         end.to raise_error NoDBAccess::DbAccessError
       end
@@ -24,58 +24,58 @@ module ExplicitActiveRecord
       it 'prevents finding even when no record are returned' do
         expect do
           no_db_access do
-            TestClass.first
+            TestModel.first
           end
         end.to raise_error NoDBAccess::DbAccessError
       end
 
       it 'prevents plucking in a pure function' do
-        TestClass.create! name: 'george'
+        TestModel.create! name: 'george'
         expect do
           no_db_access do
-            expect(TestClass.pluck(:name)).to eq(['george'])
+            expect(TestModel.pluck(:name)).to eq(['george'])
           end
         end.to raise_error NoDBAccess::DbAccessError
       end
 
       it 'prevents dynamic finds in a pure function' do
-        TestClass.create! name: 'george'
+        TestModel.create! name: 'george'
         expect do
           no_db_access do
-            expect(TestClass.find_by_name('george')).to eq TestClass.first
+            expect(TestModel.find_by_name('george')).to eq TestModel.first
           end
         end.to raise_error NoDBAccess::DbAccessError
       end
 
       it 'prevents joins in a pure function' do
-        test_class = TestClass.create!
-        5.times { OtherTestClass.create!(test_class_id: test_class.id) }
+        test_model = TestModel.create!
+        5.times { OtherTestModel.create!(test_model_id: test_model.id) }
         expect do
           no_db_access do
-            expect(TestClass.joins(:other_test_classes).uniq).to eq([TestClass.first])
+            expect(TestModel.joins(:other_test_models).uniq).to eq([TestModel.first])
           end
         end.to raise_error NoDBAccess::DbAccessError
       end
 
       it 'prevents finding in a pure function' do
-        TestClass.create! name: 'george'
+        TestModel.create! name: 'george'
         expect do
           no_db_access do
-            TestClass.first
+            TestModel.first
           end
         end.to raise_error NoDBAccess::DbAccessError
       end
 
       it 'prevents saving in a pure function' do
-        test_class = TestClass.create! name: 'george'
+        test_model = TestModel.create! name: 'george'
         puts 'point 1'
         no_db_access do
-          test_class.name = 'bob'
+          test_model.name = 'bob'
         end
         expect do
           puts 'point 2'
           no_db_access do
-            test_class.save!
+            test_model.save!
           end
         end.to raise_error NoDBAccess::DbAccessError
       end
@@ -83,16 +83,16 @@ module ExplicitActiveRecord
       it 'prevents creating in a pure function' do
         expect do
           no_db_access do
-            TestClass.create! name: 'stuff'
+            TestModel.create! name: 'stuff'
           end
         end.to raise_error NoDBAccess::DbAccessError
       end
 
       it 'prevents destroying in a pure function' do
-        test_class = TestClass.create! name: 'stuff'
+        test_model = TestModel.create! name: 'stuff'
         expect do
           no_db_access do
-            test_class.destroy
+            test_model.destroy
           end
         end.to raise_error NoDBAccess::DbAccessError
       end

--- a/spec/explicit_activerecord/persistence_spec.rb
+++ b/spec/explicit_activerecord/persistence_spec.rb
@@ -3,26 +3,26 @@
 # rubocop:disable Rails/ApplicationRecord
 describe ExplicitActiveRecord::Persistence do # rubocop:disable RSpec/FilePath
   before do
-    TestClass.include(ExplicitActiveRecord::Persistence)
-    OtherTestClass.include(ExplicitActiveRecord::Persistence)
+    TestModel.include(ExplicitActiveRecord::Persistence)
+    OtherTestModel.include(ExplicitActiveRecord::Persistence)
   end
 
   after do
-    TestClass.dangerous_update_behaviors = []
+    TestModel.dangerous_update_behaviors = []
   end
 
   describe 'raise' do
     before do
-      TestClass.dangerous_update_behaviors = [DeprecationHelper::Strategies::RaiseError.new]
+      TestModel.dangerous_update_behaviors = [DeprecationHelper::Strategies::RaiseError.new]
     end
 
-    let(:instance) { TestClass.new }
+    let(:instance) { TestModel.new }
 
     context 'an error is thrown after permitting' do
       let(:error_message) { 'ERROR DURING PERMITTED PERSISTENCE' }
 
       subject do
-        TestClass.with_explicit_persistence_for(instance) do
+        TestModel.with_explicit_persistence_for(instance) do
           raise error_message
         end
       end
@@ -38,19 +38,19 @@ describe ExplicitActiveRecord::Persistence do # rubocop:disable RSpec/FilePath
     context 'create' do
       context 'when not permitted' do
         it 'raises when attempting to create without permission' do
-          current_count = TestClass.count
+          current_count = TestModel.count
           expect { instance.save! }.to(raise_error { |error|
             expect(error).to be_a(DeprecationHelper::DeprecationException)
-            expect(error.message).to eq('TestClass instances should only be persisted explicitly')
+            expect(error.message).to eq('TestModel instances should only be persisted explicitly')
           })
-          expect(TestClass.count).to eq current_count
+          expect(TestModel.count).to eq current_count
         end
       end
 
       context 'when permitted' do
         it 'successfully creates the record' do
-          TestClass.with_explicit_persistence_for(instance) do
-            expect { instance.save! }.to change(TestClass, :count).by(1)
+          TestModel.with_explicit_persistence_for(instance) do
+            expect { instance.save! }.to change(TestModel, :count).by(1)
           end
         end
       end
@@ -58,7 +58,7 @@ describe ExplicitActiveRecord::Persistence do # rubocop:disable RSpec/FilePath
       context 'when override is set' do
         it 'successfully creates the record' do
           instance.instance_variable_set(:@can_be_dangerously_updated, true)
-          expect { instance.save! }.to change(TestClass, :count).by(1)
+          expect { instance.save! }.to change(TestModel, :count).by(1)
         end
       end
     end
@@ -67,7 +67,7 @@ describe ExplicitActiveRecord::Persistence do # rubocop:disable RSpec/FilePath
       let(:key) { 'baz' }
 
       before do
-        TestClass.with_explicit_persistence_for(instance) do
+        TestModel.with_explicit_persistence_for(instance) do
           instance.save!
         end
       end
@@ -77,10 +77,10 @@ describe ExplicitActiveRecord::Persistence do # rubocop:disable RSpec/FilePath
           it 'raises when attempting to update' do
             expect { instance.update!(key: key) }.to(raise_error do |error|
               expect(error).to be_a(DeprecationHelper::DeprecationException)
-              expect(error.message).to eq('TestClass instances should only be persisted explicitly')
+              expect(error.message).to eq('TestModel instances should only be persisted explicitly')
             end)
 
-            TestClass.with_explicit_persistence_for(instance) do
+            TestModel.with_explicit_persistence_for(instance) do
               expect(instance.reload.key).to_not eq(key)
             end
           end
@@ -88,7 +88,7 @@ describe ExplicitActiveRecord::Persistence do # rubocop:disable RSpec/FilePath
 
         context 'when permitted' do
           it 'successfully updates the record' do
-            TestClass.with_explicit_persistence_for(instance) do
+            TestModel.with_explicit_persistence_for(instance) do
               expect { instance.update!(key: key) }.to change(instance, :key).to(key)
             end
           end
@@ -105,19 +105,19 @@ describe ExplicitActiveRecord::Persistence do # rubocop:disable RSpec/FilePath
       context 'destroy' do
         context 'when not permitted' do
           it 'raises when attempting to destroy' do
-            current_count = TestClass.count
+            current_count = TestModel.count
             expect { instance.destroy! }.to(raise_error { |error|
               expect(error).to be_a(DeprecationHelper::DeprecationException)
-              expect(error.message).to eq('TestClass instances should only be persisted explicitly')
+              expect(error.message).to eq('TestModel instances should only be persisted explicitly')
             })
-            expect(TestClass.count).to eq current_count
+            expect(TestModel.count).to eq current_count
           end
         end
 
         context 'when permitted' do
           it 'successfully destroys the record' do
-            TestClass.with_explicit_persistence_for(instance) do
-              expect { instance.destroy! }.to change(TestClass, :count).by(-1)
+            TestModel.with_explicit_persistence_for(instance) do
+              expect { instance.destroy! }.to change(TestModel, :count).by(-1)
             end
           end
         end
@@ -125,7 +125,7 @@ describe ExplicitActiveRecord::Persistence do # rubocop:disable RSpec/FilePath
         context 'when override is set' do
           it 'successfully destroys the record' do
             instance.instance_variable_set(:@can_be_dangerously_updated, true)
-            expect { instance.destroy! }.to change(TestClass, :count).by(-1)
+            expect { instance.destroy! }.to change(TestModel, :count).by(-1)
           end
         end
       end
@@ -134,22 +134,22 @@ describe ExplicitActiveRecord::Persistence do # rubocop:disable RSpec/FilePath
 
   describe 'noop strategy' do
     before do
-      TestClass.dangerous_update_behaviors = []
+      TestModel.dangerous_update_behaviors = []
     end
 
-    let(:instance) { TestClass.new }
+    let(:instance) { TestModel.new }
 
     context 'create' do
       context 'when not permitted' do
         it 'does not notify to bugsnag during the create' do
-          expect { instance.save! }.to change(TestClass, :count).by(1)
+          expect { instance.save! }.to change(TestModel, :count).by(1)
         end
       end
 
       context 'when permitted' do
         it 'successfully creates the record and does not notify to bugsnag' do
-          TestClass.with_explicit_persistence_for(instance) do
-            expect { instance.save! }.to change(TestClass, :count).by(1)
+          TestModel.with_explicit_persistence_for(instance) do
+            expect { instance.save! }.to change(TestModel, :count).by(1)
           end
         end
       end
@@ -157,7 +157,7 @@ describe ExplicitActiveRecord::Persistence do # rubocop:disable RSpec/FilePath
       context 'when override is set' do
         it 'successfully creates the record and does not notify to bugsnag' do
           instance.instance_variable_set(:@can_be_dangerously_updated, true)
-          expect { instance.save! }.to change(TestClass, :count).by(1)
+          expect { instance.save! }.to change(TestModel, :count).by(1)
         end
       end
     end
@@ -166,7 +166,7 @@ describe ExplicitActiveRecord::Persistence do # rubocop:disable RSpec/FilePath
       let(:key) { 'baz' }
 
       before do
-        TestClass.with_explicit_persistence_for(instance) do
+        TestModel.with_explicit_persistence_for(instance) do
           instance.save!
         end
       end
@@ -180,7 +180,7 @@ describe ExplicitActiveRecord::Persistence do # rubocop:disable RSpec/FilePath
 
         context 'when permitted' do
           it 'successfully updates the record' do
-            TestClass.with_explicit_persistence_for(instance) do
+            TestModel.with_explicit_persistence_for(instance) do
               expect { instance.update!(key: key) }.to change(instance, :key).to(key)
             end
           end
@@ -197,14 +197,14 @@ describe ExplicitActiveRecord::Persistence do # rubocop:disable RSpec/FilePath
       context 'destroy' do
         context 'when not permitted' do
           it 'does not notify to bugsnag during the destroy' do
-            expect { instance.destroy! }.to change(TestClass, :count).by(-1)
+            expect { instance.destroy! }.to change(TestModel, :count).by(-1)
           end
         end
 
         context 'when permitted' do
           it 'successfully destroys the record' do
-            TestClass.with_explicit_persistence_for(instance) do
-              expect { instance.destroy! }.to change(TestClass, :count).by(-1)
+            TestModel.with_explicit_persistence_for(instance) do
+              expect { instance.destroy! }.to change(TestModel, :count).by(-1)
             end
           end
         end
@@ -212,7 +212,7 @@ describe ExplicitActiveRecord::Persistence do # rubocop:disable RSpec/FilePath
         context 'when override is set' do
           it 'successfully destroys the record' do
             instance.instance_variable_set(:@can_be_dangerously_updated, true)
-            expect { instance.destroy! }.to change(TestClass, :count).by(-1)
+            expect { instance.destroy! }.to change(TestModel, :count).by(-1)
           end
         end
       end
@@ -221,30 +221,30 @@ describe ExplicitActiveRecord::Persistence do # rubocop:disable RSpec/FilePath
 
   describe 'with_explicit_persistence_for' do
     before do
-      TestClass.dangerous_update_behaviors = [DeprecationHelper::Strategies::RaiseError.new]
+      TestModel.dangerous_update_behaviors = [DeprecationHelper::Strategies::RaiseError.new]
     end
 
-    let(:instance) { TestClass.new }
-    let(:instance_2) { TestClass.new }
-    let(:instance_3) { TestClass.new }
+    let(:instance) { TestModel.new }
+    let(:instance_2) { TestModel.new }
+    let(:instance_3) { TestModel.new }
 
     it 'raise an error if the instance is not if the same class that is extending the concern' do
-      expect { OtherTestClass.with_explicit_persistence_for(instance) { instance.save! } }.to raise_error do |error|
+      expect { OtherTestModel.with_explicit_persistence_for(instance) { instance.save! } }.to raise_error do |error|
         expect(error).to be_a(ExplicitActiveRecord::Persistence::InvalidInstanceOfClassError)
-        expect(error.message).to eq('The provided instances of (TestClass) are not an instance of the class (OtherTestClass) extending this concern.')
+        expect(error.message).to eq('The provided instances of (TestModel) are not an instance of the class (OtherTestModel) extending this concern.')
       end
     end
 
     it 'raise an error if the instances are not if the same class that is extending the concern' do
-      expect { OtherTestClass.with_explicit_persistence_for([instance, instance_2]) { instance.save! } }.to raise_error do |error|
+      expect { OtherTestModel.with_explicit_persistence_for([instance, instance_2]) { instance.save! } }.to raise_error do |error|
         expect(error).to be_a(ExplicitActiveRecord::Persistence::InvalidInstanceOfClassError)
-        expect(error.message).to eq('The provided instances of (TestClass and TestClass) are not an instance of the class (OtherTestClass) extending this concern.')
+        expect(error.message).to eq('The provided instances of (TestModel and TestModel) are not an instance of the class (OtherTestModel) extending this concern.')
       end
     end
 
     context 'create' do
       it "successfully creates the record when wrapping the call within the 'with_explicit_persistence_for' block" do
-        expect { TestClass.with_explicit_persistence_for(instance) { instance.save! } }.to change(TestClass, :count).by(1)
+        expect { TestModel.with_explicit_persistence_for(instance) { instance.save! } }.to change(TestModel, :count).by(1)
       end
     end
 
@@ -252,20 +252,20 @@ describe ExplicitActiveRecord::Persistence do # rubocop:disable RSpec/FilePath
       let(:key) { 'baz' }
 
       before do
-        TestClass.with_explicit_persistence_for(instance) do
+        TestModel.with_explicit_persistence_for(instance) do
           instance.save!
         end
       end
 
       context 'update' do
         it "successfully updates the record when wrapping the call within the 'with_explicit_persistence_for' block" do
-          expect { TestClass.with_explicit_persistence_for(instance) { |_| instance.update!(key: key) } }.to change(instance, :key).to(key)
+          expect { TestModel.with_explicit_persistence_for(instance) { |_| instance.update!(key: key) } }.to change(instance, :key).to(key)
         end
       end
 
       context 'destroy' do
         it "successfully destroys the record when wrapping the call within the 'with_explicit_persistence_for' block" do
-          expect { TestClass.with_explicit_persistence_for(instance) { |_| instance.destroy! } }.to change(TestClass, :count).by(-1)
+          expect { TestModel.with_explicit_persistence_for(instance) { |_| instance.destroy! } }.to change(TestModel, :count).by(-1)
         end
       end
     end
@@ -273,21 +273,21 @@ describe ExplicitActiveRecord::Persistence do # rubocop:disable RSpec/FilePath
     context 'multiple instances' do
       it "successfully creates the records when wrapping the call within the 'with_explicit_persistence_for' block" do
         my_model_save = proc do
-          TestClass.with_explicit_persistence_for([instance, instance_2, instance_3]) do
+          TestModel.with_explicit_persistence_for([instance, instance_2, instance_3]) do
             # these are intentionally saved out of order to ensure that they can be saved out of order
             instance_3.save!
             instance.save!
             instance_2.save!
           end
         end
-        expect { my_model_save.call }.to change(TestClass, :count).by(3)
+        expect { my_model_save.call }.to change(TestModel, :count).by(3)
       end
     end
 
     context 'zero instances' do
       it 'executes the block and does not error' do
         block_was_called = false
-        TestClass.with_explicit_persistence_for(nil) do
+        TestModel.with_explicit_persistence_for(nil) do
           block_was_called = true
         end
         expect(block_was_called).to eq true
@@ -296,8 +296,8 @@ describe ExplicitActiveRecord::Persistence do # rubocop:disable RSpec/FilePath
 
     context 'nested calls for the same model' do
       subject(:persist!) do
-        TestClass.with_explicit_persistence_for(instance) do
-          TestClass.with_explicit_persistence_for(instance) do
+        TestModel.with_explicit_persistence_for(instance) do
+          TestModel.with_explicit_persistence_for(instance) do
             instance.save!
           end
           instance.save!
@@ -316,12 +316,12 @@ describe ExplicitActiveRecord::Persistence do # rubocop:disable RSpec/FilePath
         DeprecationHelper::Strategies::LogError.new,
       ]
       DeprecationHelper.configure { |config| config.deprecation_strategies = global_strategies }
-      expect(OtherTestClass.dangerous_update_behaviors).to eq global_strategies
+      expect(OtherTestModel.dangerous_update_behaviors).to eq global_strategies
 
       configured_behaviors = [DeprecationHelper::Strategies::RaiseError.new]
-      OtherTestClass.dangerous_update_behaviors = configured_behaviors
+      OtherTestModel.dangerous_update_behaviors = configured_behaviors
 
-      expect(OtherTestClass.dangerous_update_behaviors).to eq configured_behaviors
+      expect(OtherTestModel.dangerous_update_behaviors).to eq configured_behaviors
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,17 +5,17 @@ require 'active_record'
 require 'pry'
 
 # This allows each test to have reference to the test class without test pollution
-def define_test_classes(config)
+def define_test_models(config)
   config.before(:each) do
     # https://makandracards.com/makandra/47189-rspec-how-to-define-classes-for-specs
-    test_class = Class.new(ActiveRecord::Base) do
-      has_many :other_test_classes
+    test_model = Class.new(ActiveRecord::Base) do
+      has_many :other_test_models
     end
 
-    other_test_class = Class.new(ActiveRecord::Base)
+    other_test_model = Class.new(ActiveRecord::Base)
 
-    stub_const('TestClass', test_class)
-    stub_const('OtherTestClass', other_test_class)
+    stub_const('TestModel', test_model)
+    stub_const('OtherTestModel', other_test_model)
   end
 end
 
@@ -26,14 +26,14 @@ def setup_database
   )
 
   ActiveRecord::Schema.define do
-    create_table :test_classes do |table|
+    create_table :test_models do |table|
       table.string :key
       table.string :name
     end
 
-    create_table :other_test_classes do |table|
+    create_table :other_test_models do |table|
       table.string :name
-      table.references :test_class
+      table.references :test_model
     end
   end
 end
@@ -57,8 +57,8 @@ end
 
 def teardown_database(config)
   config.after do
-    ActiveRecord::Base.connection.execute('delete from test_classes')
-    ActiveRecord::Base.connection.execute('delete from other_test_classes')
+    ActiveRecord::Base.connection.execute('delete from test_models')
+    ActiveRecord::Base.connection.execute('delete from other_test_models')
   end
 end
 
@@ -85,7 +85,7 @@ RSpec.configure do |config|
   end
 
   setup_global_deprecation_helper_behavior(config)
-  define_test_classes(config)
+  define_test_models(config)
   setup_database
   make_sorbet_signatures_noop
   teardown_database(config)


### PR DESCRIPTION
In this PR, I wanted to improve some of the test setup and configuration to make adding future test cases a bit easier.

In this PR, I conform both tests (`Persistence` and `NoDbAccess` to use the same tables defined in `spec_helper`. I stub the model constants in a way that lets me change what modules are included in them in each suite without polluting the other suite. I also make the names a bit less verbose.