### PR TITLE
Bump sorbet version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,10 +46,10 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.2)
-    sorbet (0.5.6295)
-      sorbet-static (= 0.5.6295)
+    sorbet (0.5.6389)
+      sorbet-static (= 0.5.6389)
     sorbet-runtime (0.5.6295)
-    sorbet-static (0.5.6295-universal-darwin-14)
+    sorbet-static (0.5.6389-universal-darwin-14)
     sqlite3 (1.4.2)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
@@ -62,7 +62,7 @@ DEPENDENCIES
   explicit_activerecord!
   pry
   rspec (~> 3.0)
-  sorbet (~> 0.5.6293)
+  sorbet (~> 0.5.6389)
   sqlite3
 
 BUNDLED WITH

--- a/explicit_activerecord.gemspec
+++ b/explicit_activerecord.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'sorbet', '~> 0.5.6293'
+  spec.add_development_dependency 'sorbet', '~> 0.5.6389'
 
   # This allows us to test ActiveRecord business logic without needing an underlying database
   spec.add_development_dependency 'sqlite3'


### PR DESCRIPTION
This bumps the version of Sorbet. The main reason I did this was to enable the use of sorbet on M1 macs. This bump gets us to a version of sorbet supported on M1 macs.﻿
