### PR TITLE
Adds TransactionGuard, which raises errors if a method is called from within a db transaction

### DIFF
--- a/lib/explicit_activerecord.rb
+++ b/lib/explicit_activerecord.rb
@@ -4,6 +4,7 @@ require 'active_support/concern'
 require 'deprecation_helper'
 require 'explicit_activerecord/persistence'
 require 'explicit_activerecord/no_db_access'
+require 'explicit_activerecord/transaction_guard'
 
 module ExplicitActiveRecord
 end

--- a/lib/explicit_activerecord/transaction_guard.rb
+++ b/lib/explicit_activerecord/transaction_guard.rb
@@ -1,0 +1,74 @@
+# typed: true
+
+# prevent callers from calling your methods within a transaction,
+# providing you with confidence that you can perform non-atomic operations, or mutate records without something downstream triggering a rollback,
+#
+# class MyService
+#   include ExplicitActiveRecord::TransactionGuard
+#
+#   def my_non_atomic_method(args)
+#     ensure_transaction_integrity!
+#     SidekiqWorker.perform_async(args)
+#   end
+#
+#   private
+#
+#   def trust_me_im_not_in_a_transaction(args)
+#     allow_transaction do
+#       my_non_atomic_method(args)
+#     end
+#   end
+# end
+
+module ExplicitActiveRecord
+  module TransactionGuard
+    extend T::Sig
+
+    class ForbiddenCallWhileInDbTransaction < StandardError; end
+
+    class << self
+      extend T::Sig
+
+      sig { returns(T.nilable(Integer)) }
+      attr_accessor :allowed_transaction_count
+
+      sig { returns(T.nilable(T::Boolean)) }
+      attr_accessor :ignore
+
+      sig { returns(Integer) }
+      def open_transactions
+        ActiveRecord::Base.connection.open_transactions
+      end
+
+      sig { returns(Integer) }
+      def excessive_transactions
+        open_transactions - (allowed_transaction_count || 0)
+      end
+    end
+
+    sig { void }
+    def ensure_transaction_integrity!
+      unless TransactionGuard.ignore == true || TransactionGuard.excessive_transactions <= 0
+        Kernel.raise ForbiddenCallWhileInDbTransaction, "This method guards against open transactions. You have called it with #{TransactionGuard.excessive_transactions} open tranactions."
+      end
+    end
+
+    sig { params(blk: T.proc.returns(T.untyped)).returns(T.untyped) }
+    def ignore_transaction_integrity!(&blk)
+      TransactionGuard.ignore = true
+      yield
+    ensure
+      TransactionGuard.ignore = false
+    end
+
+    sig { params(blk: T.proc.returns(T.untyped)).returns(T.untyped) }
+    def allow_transaction(&blk)
+      TransactionGuard.allowed_transaction_count ||= 0
+      TransactionGuard.allowed_transaction_count = T.must(TransactionGuard.allowed_transaction_count) + 1
+      yield
+    ensure
+      TransactionGuard.allowed_transaction_count = T.must(TransactionGuard.allowed_transaction_count) - 1
+    end
+  end
+end
+

--- a/spec/explicit_activerecord/transaction_guard_spec.rb
+++ b/spec/explicit_activerecord/transaction_guard_spec.rb
@@ -1,0 +1,57 @@
+# typed: ignore
+
+module ExplicitActiveRecord
+  describe TransactionGuard do
+    include TransactionGuard
+
+    describe '#ensure_transaction_integrity!' do
+      subject(:with_transaction_integrity) { ensure_transaction_integrity!; true }
+
+      context 'when called while not in a transaction' do
+        it { is_expected.to be true }
+      end
+
+      context 'when called within a transaction' do
+        subject(:with_transaction) do
+          TestModel.transaction(requires_new: true, joinable: false) do
+            with_transaction_integrity
+          end
+        end
+
+        it 'raises ForbiddenCallWhileInDbTransaction' do
+          expect { subject }.to raise_error TransactionGuard::ForbiddenCallWhileInDbTransaction
+        end
+
+        describe '#ignore_transaction_integrity!' do
+          subject do
+            ignore_transaction_integrity! do
+              with_transaction
+            end
+          end
+
+          it { is_expected.to be true }
+        end
+
+        describe '#allow_transaction' do
+          subject(:with_single_transaction_allowed) do
+            allow_transaction { with_transaction }
+          end
+
+          it { is_expected.to be true }
+
+          context 'but it is called within two transactions' do
+            subject do
+              TestModel.transaction(requires_new: true, joinable: false) do
+                with_single_transaction_allowed
+              end
+            end
+
+            it 'raises ForbiddenCallWhileInDbTransaction' do
+              expect { subject }.to raise_error TransactionGuard::ForbiddenCallWhileInDbTransaction
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
As noted in the README, this add `TransactionGuard`, a module that allows for preventing methods being called within a database transaction. Consider:

```ruby
def schedule_worker_and_update_status
  model = Model.new(...)
  model.save!
  SidekiqWorker.perform_async(model.id)
  model.update!(status: :scheduled)
  model
end
```

But support this method is called by:

```ruby
ActiveRecord::Base.transaction do
  model = schedule_worker_and_update_status
  model.update!(some_other_attribute: false) # what if this raises?
end
```

If there is a failure to save `model` with a status of `:scheduled`, then `SidekiqWorker` will be scheduled using an id that is at best not found, and at worst corresponding to a _different_ record that was inserted in a different process.

By making this explicit, you can be confident that changes you persist will not be rolled back (unless by your method):

```ruby
include ExplicitActiveRecord::TransactionGuard

def schedule_worker_and_update_status
  ensure_transaction_integrity!
  # ...
end
```

Now, this will raise:

```ruby
ActiveRecord::Base.transaction do
  model = schedule_worker_and_update_status # raises because you're in a transaction
  model.update!(some_other_attribute: false) # what if this raises?
end
```

NOTE: If you are using postgres, `ActiveRecord::Base.connection.open_transactions` will return either 0 or 1 unless you pass `requires_new: true, joinable: false` to `transaction`, which is important to keep in mind. Rspec, for example, might be configured to run all your tests in a transaction, which means all code will be in a transaction, so you'll need to know how _many_ transactions you have open.