### PR TITLE
Migrate from Gemstash to Cloudsmith

### DIFF
--- a/.buildkite/docker-compose.yml
+++ b/.buildkite/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   app:
     build:

--- a/.buildkite/docker-compose.yml
+++ b/.buildkite/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3'
+services:
+  app:
+    build:
+      context: ../
+      dockerfile: Dockerfile.test
+      secrets:
+        - cloudsmith_api_key
+    environment:
+      BUILDKITE:
+      BUILDKITE_AGENT_ACCESS_TOKEN:
+      BUILDKITE_BRANCH:
+      BUILDKITE_BUILD_ID:
+      BUILDKITE_BUILD_NUMBER:
+      BUILDKITE_BUILD_URL:
+      BUILDKITE_COMMAND:
+      BUILDKITE_COMMIT:
+      BUILDKITE_JOB_ID:
+      BUILDKITE_PIPELINE_SLUG:
+      BUILDKITE_REPO:
+      CLOUDSMITH_API_KEY:
+secrets:
+  cloudsmith_api_key:
+    environment: CLOUDSMITH_API_KEY

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,15 +2,25 @@ steps:
   - name: ':rspec: RSpec'
     command: test.sh
     timeout_in_minutes: 10
-    env:
-      BUILDKITE_DOCKER: 'true'
-      BUILDKITE_DOCKER_FILE: 'Dockerfile.test'
+    plugins:
+      - ssh://git@github.com/Gusto/cloudsmith-auth-buildkite-plugin.git#v2.2.0: ~
+      - docker-compose#v5.6.0:
+          run: app
+          config: .buildkite/docker-compose.yml
+          env:
+            - BUNDLE_DL__CLOUDSMITH__IO
+            - CLOUDSMITH_API_KEY
   - name: ':sorbet: Sorbet typecheck'
     command: typecheck.sh
     timeout_in_minutes: 10
-    env:
-      BUILDKITE_DOCKER: 'true'
-      BUILDKITE_DOCKER_FILE: 'Dockerfile.test'
+    plugins:
+      - ssh://git@github.com/Gusto/cloudsmith-auth-buildkite-plugin.git#v2.2.0: ~
+      - docker-compose#v5.6.0:
+          run: app
+          config: .buildkite/docker-compose.yml
+          env:
+            - BUNDLE_DL__CLOUDSMITH__IO
+            - CLOUDSMITH_API_KEY
   - wait
   - block: ':rocket: Publish to Gem Server?'
     branches: main
@@ -19,4 +29,3 @@ steps:
     agents:
       queue: gemstash-publish
     command: gem build explicit_activerecord.gemspec && .buildkite/store_rubygems_key.sh && gem push --key rubygems *.gem
-

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,6 @@
 steps:
   - name: ':rspec: RSpec'
-    command: test.sh
+    command: ./test.sh
     timeout_in_minutes: 10
     plugins:
       - ssh://git@github.com/Gusto/cloudsmith-auth-buildkite-plugin.git#v2.2.0: ~
@@ -11,7 +11,7 @@ steps:
             - BUNDLE_DL__CLOUDSMITH__IO
             - CLOUDSMITH_API_KEY
   - name: ':sorbet: Sorbet typecheck'
-    command: typecheck.sh
+    command: ./typecheck.sh
     timeout_in_minutes: 10
     plugins:
       - ssh://git@github.com/Gusto/cloudsmith-auth-buildkite-plugin.git#v2.2.0: ~

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.10.0
 FROM ruby:3.4.5
 
 # Setup the buildkite-agent user/group
@@ -9,11 +10,10 @@ RUN groupadd -r buildkite-agent && \
 ENV APP_HOME /var/www
 WORKDIR $APP_HOME
 
-# Setup bundler options to install gems in the work directory and use our gem mirror
+# Setup bundler options to install gems in the work directory
 RUN gem install bundler && \
       bundle config --local app_config /usr/local/bundle/config && \
       bundle config --local path vendor/bundle && \
-      bundle config --local "mirror.https://rubygems.org" "https://gemstash.zp-int.com" && \
       mkdir /home/buildkite-agent/.gem # This is needed for publishing gems from inside your container
 
 # RAILS APP: Add Gemfile and Gemfile.lock to the work directory
@@ -22,8 +22,10 @@ COPY Gemfile* $APP_HOME/
 # LIBRARY: Add Gemfile, Gemfile.lock, and gemspec to the work directory
 COPY Gemfile* explicit_activerecord.gemspec $APP_HOME/
 
-# Run bundle install with minimal dependencies
-RUN bundle install
+# Run bundle install with Cloudsmith credentials
+RUN --mount=type=secret,id=cloudsmith_api_key,env=CLOUDSMITH_API_KEY \
+      BUNDLE_DL__CLOUDSMITH__IO="token:${CLOUDSMITH_API_KEY}" \
+      bundle install
 
 # Add the rest of the source, now that dependencies are installed
 COPY . $APP_HOME

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source 'https://dl.cloudsmith.io/basic/gusto/gusto/ruby/'
 
 # Specify your gem's dependencies in explicit_activerecord.gemspec
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       sorbet-runtime (>= 0.5.6293)
 
 GEM
-  remote: https://rubygems.org/
+  remote: https://dl.cloudsmith.io/basic/gusto/gusto/ruby/
   specs:
     activemodel (8.0.2.1)
       activesupport (= 8.0.2.1)


### PR DESCRIPTION
## Summary

Gemstash is being sunset org-wide; this PR moves the repo onto Cloudsmith for read-path access to private gems and adopts the canonical `cloudsmith-auth-buildkite-plugin` for CI credential minting.

The publish step still pushes to public rubygems.org (`gem push --key rubygems`) — that is unaffected by the Gemstash sunset. The `agents queue: gemstash-publish` label is preserved verbatim per migration convention (it is a queue label, not a coupling to Gemstash; the queue still has the publish-specific network/permissions config).

## Changes

- `Gemfile` — source URL swapped from `https://rubygems.org` to `https://dl.cloudsmith.io/basic/gusto/gusto/ruby/`. Cloudsmith proxies rubygems.org transparently for public gems, so one source covers both private and public deps.
- `Gemfile.lock` — `remote:` URL updated to match the Gemfile. Hand-edited (not regenerated locally); bundler will reconcile on the first CI run.
- `Dockerfile.test` —
  - added `# syntax=docker/dockerfile:1.10.0` directive for `--mount=type=secret` support.
  - dropped the legacy `bundle config --local "mirror.https://rubygems.org" "https://gemstash.zp-int.com"` line; not needed once the source is Cloudsmith.
  - the `bundle install` RUN now mounts the `cloudsmith_api_key` BuildKit secret and assigns `BUNDLE_DL__CLOUDSMITH__IO` inline on the same line.
- `.buildkite/docker-compose.yml` (new) — wires the `cloudsmith_api_key` secret into the docker build context (sourced from the `CLOUDSMITH_API_KEY` env var minted by the cloudsmith-auth plugin) and forwards `CLOUDSMITH_API_KEY` to the runner container.
- `.buildkite/pipeline.yml` —
  - rspec and sorbet steps moved off the legacy `BUILDKITE_DOCKER`/`BUILDKITE_DOCKER_FILE` env-based docker driver and onto the `docker-compose#v5.6.0` plugin, with `cloudsmith-auth-buildkite-plugin#v2.2.0` attached for credential minting.
  - publish step is untouched apart from re-grouping; same command, same `gemstash-publish` queue.

## Validation

- YAML files parse cleanly (`pipeline.yml`, `docker-compose.yml`).
- CI will exercise the end-to-end read path on first build of this PR.
- Pattern matches `Gusto/danger-gusto` (same agent/queue/topology, also-published gem).

## Rollback

Revert this PR. Gemstash continues to serve in parallel during the sunset window, so the previous read path is recoverable until Gemstash is fully retired.