### PR TITLE
Add catalog-info.yaml (component registration for buildkite security remediation)

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: explicit_activerecord
+  description: This gem helps you use ActiveRecord more explicitly.
+  annotations:
+    github.com/project-slug: gusto/explicit_activerecord
+    buildkite.com/project-slug: gusto/explicitactiverecord
+spec:
+  type: library
+  owner: team-product-infrastructure-modularity
+  lifecycle: stable


### PR DESCRIPTION
Registers this repo in the Backstage catalog so it gets a component definition, unblocking its observe-only XGitRepository import (part of the Buildkite required-status-check remediation). Owner derived from CODEOWNERS/committers; lifecycle: stable. Please correct owner/type if off.